### PR TITLE
Update code to work with Twig v3

### DIFF
--- a/Twig/InlineCssExtension.php
+++ b/Twig/InlineCssExtension.php
@@ -13,10 +13,10 @@ namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
 use RobertoTru\ToInlineStyleEmailBundle\Converter\ToInlineStyleEmailConverter;
 use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Component\Templating\TemplateNameParserInterface;
 use Twig\Extension\GlobalsInterface as TwigExtensionGlobalsInterface;
+use Twig\Extension\AbstractExtension;
 
-class InlineCssExtension extends \Twig_Extension implements TwigExtensionGlobalsInterface
+class InlineCssExtension extends AbstractExtension implements TwigExtensionGlobalsInterface
 {
     /**
      * @var ToInlineStyleEmailConverter

--- a/Twig/InlineCssNode.php
+++ b/Twig/InlineCssNode.php
@@ -11,19 +11,20 @@
 
 namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
-use Twig_Compiler;
+use Twig\Compiler;
+use Twig\Node;
 
-class InlineCssNode extends \Twig_Node
+class InlineCssNode extends Node
 {
     private $debug;
 
-    public function __construct(\Twig_Node $body, $css, $lineno = 0, $debug, $tag = 'inlinecss')
+    public function __construct(Node $body, $css, $lineno = 0, $debug, $tag = 'inlinecss')
     {
         $this->debug = $debug;
         parent::__construct(array('body' => $body), array('css' => $css), $lineno, $tag);
     }
 
-    public function compile(Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         if (is_string($this->getAttribute('css'))) {
             if ($this->debug) {
@@ -48,6 +49,5 @@ class InlineCssNode extends \Twig_Node
                 ->write('echo $context["inlinecss"]->inlineCSS(ob_get_clean(), $css);' . "\n")
             ;
         }
-
     }
 }

--- a/Twig/InlineCssParser.php
+++ b/Twig/InlineCssParser.php
@@ -12,11 +12,11 @@
 namespace RobertoTru\ToInlineStyleEmailBundle\Twig;
 
 use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Component\Templating\TemplateNameParserInterface;
-use Twig_Node;
-use Twig_Token;
+use Twig\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
-class InlineCssParser extends \Twig_TokenParser
+class InlineCssParser extends AbstractTokenParser
 {
     /**
      * @var FileLocatorInterface
@@ -48,22 +48,22 @@ class InlineCssParser extends \Twig_TokenParser
     /**
      * Parses a token and returns a node.
      *
-     * @param Twig_Token $token A Twig_Token instance
+     * @param Twig\Token $token A Twig\Token instance
      *
-     * @return Twig_Node A Twig_Node instance
+     * @return Twig\Node A Twig_Node instance
      */
-    public function parse(Twig_Token $token)
+    public function parse(Token $token)
     {
         $lineNo = $token->getLine();
         $stream = $this->parser->getStream();
-        if ($stream->test(Twig_Token::STRING_TYPE)) {
-            $css = $this->resolvePath($stream->expect(Twig_Token::STRING_TYPE)->getValue());
+        if ($stream->test(Token::STRING_TYPE)) {
+            $css = $this->resolvePath($stream->expect(Token::STRING_TYPE)->getValue());
         } else {
             $css = $this->parser->getExpressionParser()->parseExpression();
         }
-        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideEnd'), true);
-        $stream->expect(Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new InlineCssNode($body, $css, $lineNo, $this->debug);
     }
@@ -78,7 +78,7 @@ class InlineCssParser extends \Twig_TokenParser
         return 'inlinecss';
     }
 
-    public function decideEnd(Twig_Token $token)
+    public function decideEnd(Token $token)
     {
         return $token->test('endinlinecss');
     }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "symfony/framework-bundle": "*",
         "phpunit/phpunit": "^4.4",
-        "twig/twig": "*"
+        "twig/twig": "^3.0"
     },
     "autoload": {
         "psr-4": { "RobertoTru\\ToInlineStyleEmailBundle\\": "" }


### PR DESCRIPTION
Updates the class names to use namespaced classes. The old way of using
global classes is discontinued.