### PR TITLE
Ensure inherited method has correct signature

### DIFF
--- a/Twig/InlineCssExtension.php
+++ b/Twig/InlineCssExtension.php
@@ -64,7 +64,7 @@ class InlineCssExtension extends AbstractExtension implements TwigExtensionGloba
     /**
      * {@inheritDoc}
      */
-    public function getGlobals()
+    public function getGlobals(): array
     {
         return array(
             'inlinecss' => $this->inlineCss,


### PR DESCRIPTION
Ensures that the getGlobals method used in the InlineCssExtension has
the correct return type so that it matches the parent class.